### PR TITLE
Added 10px to all offset-by-x css classes. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,24 +14,24 @@
 	<!--[if lt IE 9]>
 		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
-	
+
 	<!-- Mobile Specific Metas
   ================================================== -->
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" /> 
-	
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+
 	<!-- CSS
   ================================================== -->
 	<link rel="stylesheet" href="stylesheets/base.css">
 	<link rel="stylesheet" href="stylesheets/skeleton.css">
 	<link rel="stylesheet" href="stylesheets/layout.css">
-	
+
 	<!-- Favicons
 	================================================== -->
 	<link rel="shortcut icon" href="images/favicon.ico">
 	<link rel="apple-touch-icon" href="images/apple-touch-icon.png">
 	<link rel="apple-touch-icon" sizes="72x72" href="images/apple-touch-icon-72x72.png" />
 	<link rel="apple-touch-icon" sizes="114x114" href="images/apple-touch-icon-114x114.png" />
-	
+
 </head>
 <body>
 
@@ -41,21 +41,21 @@
 
 	<!-- Primary Page Layout
 	================================================== -->
-	
+
 	<!-- Delete everything in this .container and get started on your own site! -->
 
-	<div class="container container-sixteen">	
+	<div class="container container-sixteen">
 		<div class="sixteen columns">
 			<h1 class="remove-bottom" style="margin-top: 40px">Skeleton</h1>
 			<h5>Version 1.0.2</h5>
 			<hr />
 		</div>
 		<div class="one-third column">
-			<h3>About Skeleton?</h3>	
+			<h3>About Skeleton?</h3>
 			<p>Skeleton is a small collection of well-organized CSS & JS files that can help you rapidly develop sites that look beautiful at any size, be it a 17" laptop screen or an iPhone. It's based on a responsive grid, but also provides very basic CSS for typography, buttons, tabs, forms and media queries. Go ahead, resize this super basic page to see the grid in action.</p>
 		</div>
 		<div class="one-third column">
-			<h3>Three Core Principles</h3>	
+			<h3>Three Core Principles</h3>
 			<p>Skeleton is built on three core principles:</p>
 			<ul class="square">
 				<li><strong>A Responsive Grid Down To Mobile</strong>: Elegant scaling from a browser to tablets to mobile.</li>
@@ -64,22 +64,30 @@
 			</ul>
 		</div>
 		<div class="one-third column">
-			<h3>Docs &amp; Support</h3>	
+			<h3>Docs &amp; Support</h3>
 			<p>The easiest way to really get started with Skeleton is to check out the full docs and info at <a href="http://www.getskeleton.com">www.getskeleton.com.</a>. Skeleton is also open-source and has a <a href="https://github.com/dhgamache/skeleton">project on git</a>, so check that out if you want to report bugs or create a pull request. If you have any questions, thoughts, concerns or feedback, please don't hesitate to email me at <a href="mailto:hi@getskeleton.com">hi@getskeleton.com</a>.</p>
 		</div>
 
 	</div><!-- container -->
 
-		
-		
-		
-		
+    <!--<div class="container container-twelve">
+        <div class="row">
+            <div class="eleven columns offset-by-one">
+                This is offset by one.
+            </div>
+        </div>
+    </div>-->
+
+
+
+
+
 	<!-- JS
 	================================================== -->
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.js"></script>
 	<script>window.jQuery || document.write("<script src='javascripts/jquery-1.5.1.min.js'>\x3C/script>")</script>
 	<script src="javascripts/app.js"></script>
-	
+
 <!-- End Document
 ================================================== -->
 </body>

--- a/stylesheets/skeleton.css
+++ b/stylesheets/skeleton.css
@@ -1,4 +1,4 @@
-/* 
+/*
 * Skeleton V1.0.2
 * Copyright 2011, Dave Gamache
 * www.getskeleton.com
@@ -10,32 +10,32 @@
 
 /* Table of Contents
 ==================================================
-	#Base 960 Grid    
+	#Base 960 Grid
 	#Tablet (Portrait)
-	#Mobile (Portrait) 
+	#Mobile (Portrait)
 	#Mobile (Landscape)
 	#Clearing */
-	
-	
 
-/* #Base 960 Grid 
+
+
+/* #Base 960 Grid
 ================================================== */
 
 	.container { position: relative; width: 960px; margin: 0 auto; padding: 0; }
 	.column, .columns { float: left; display: inline; margin-left: 10px; margin-right: 10px; }
 	.row { margin-bottom: 20px; }
-	
+
 	/* Nested Column Classes */
 	.column.alpha, .columns.alpha 						{ margin-left: 0; }
 	.column.omega, .columns.omega 						{ margin-right: 0; }
-	
+
 	.container .one-third.column						{ width: 300px; }
 	.container .two-thirds.column						{ width: 620px; }
-	
+
 	/*****************************
 		12 Column
 	*****************************/
-	
+
 	/* Base Grid */
 	.container-twelve .one.column 						{ width: 60px;  }
 	.container-twelve .two.columns 						{ width: 140px; }
@@ -43,31 +43,31 @@
 	.container-twelve .four.columns 					{ width: 300px; }
 	.container-twelve .five.columns 					{ width: 380px; }
 	.container-twelve .six.columns 						{ width: 460px; }
-	.container-twelve .seven.columns 					{ width: 540px; }	
+	.container-twelve .seven.columns 					{ width: 540px; }
 	.container-twelve .eight.columns 					{ width: 620px; }
 	.container-twelve .nine.columns 					{ width: 700px; }
-	.container-twelve .ten.columns 						{ width: 780px; }	
-	.container-twelve .eleven.columns 					{ width: 860px; }	
+	.container-twelve .ten.columns 						{ width: 780px; }
+	.container-twelve .eleven.columns 					{ width: 860px; }
 	.container-twelve .twelve.columns 					{ width: 940px; }
-	
-	/* Offsets */	
-	.container-twelve .offset-by-one 					{ margin-left: 80px;  }
-	.container-twelve .offset-by-two 					{ margin-left: 160px; }
-	.container-twelve .offset-by-three 					{ margin-left: 240px; }
-	.container-twelve .offset-by-four 					{ margin-left: 320px; }
-	.container-twelve .offset-by-five 					{ margin-left: 400px; }
-	.container-twelve .offset-by-six 					{ margin-left: 480px; }
-	.container-twelve .offset-by-seven 					{ margin-left: 560px; }
-	.container-twelve .offset-by-eight 					{ margin-left: 640px; }
-	.container-twelve .offset-by-nine 					{ margin-left: 720px; }
-	.container-twelve .offset-by-ten 					{ margin-left: 800px; }
-	.container-twelve .offset-by-eleven 				{ margin-left: 880px; }
 
-	
+	/* Offsets */
+	.container-twelve .offset-by-one 					{ margin-left: 90px;  }
+	.container-twelve .offset-by-two 					{ margin-left: 170px; }
+	.container-twelve .offset-by-three 					{ margin-left: 250px; }
+	.container-twelve .offset-by-four 					{ margin-left: 330px; }
+	.container-twelve .offset-by-five 					{ margin-left: 410px; }
+	.container-twelve .offset-by-six 					{ margin-left: 490px; }
+	.container-twelve .offset-by-seven 					{ margin-left: 570px; }
+	.container-twelve .offset-by-eight 					{ margin-left: 650px; }
+	.container-twelve .offset-by-nine 					{ margin-left: 730px; }
+	.container-twelve .offset-by-ten 					{ margin-left: 810px; }
+	.container-twelve .offset-by-eleven 				{ margin-left: 890px; }
+
+
 	/*****************************
 		16 Column
 	*****************************/
-	
+
 	/* Base Grid */
 	.container-sixteen .one.column 						{ width: 40px;  }
 	.container-sixteen .two.columns 					{ width: 100px; }
@@ -75,193 +75,145 @@
 	.container-sixteen .four.columns 					{ width: 220px; }
 	.container-sixteen .five.columns 					{ width: 280px; }
 	.container-sixteen .six.columns 					{ width: 340px; }
-	.container-sixteen .seven.columns 					{ width: 400px; }	
+	.container-sixteen .seven.columns 					{ width: 400px; }
 	.container-sixteen .eight.columns 					{ width: 460px; }
 	.container-sixteen .nine.columns 					{ width: 520px; }
-	.container-sixteen .ten.columns 					{ width: 580px; }	
-	.container-sixteen .eleven.columns 					{ width: 640px; }	
+	.container-sixteen .ten.columns 					{ width: 580px; }
+	.container-sixteen .eleven.columns 					{ width: 640px; }
 	.container-sixteen .twelve.columns 					{ width: 700px; }
-	.container-sixteen .thirteen.columns 				{ width: 760px; }	
-	.container-sixteen .fourteen.columns 				{ width: 820px; }	
+	.container-sixteen .thirteen.columns 				{ width: 760px; }
+	.container-sixteen .fourteen.columns 				{ width: 820px; }
 	.container-sixteen .fifteen.columns 				{ width: 880px; }
 	.container-sixteen .sixteen.columns 				{ width: 940px; }
-	
-	/* Offsets */	
-	.container-sixteen .offset-by-one 					{ margin-left: 60px;  }
-	.container-sixteen .offset-by-two 					{ margin-left: 120px; }
-	.container-sixteen .offset-by-three 				{ margin-left: 180px; }
-	.container-sixteen .offset-by-four 					{ margin-left: 240px; }
-	.container-sixteen .offset-by-five 					{ margin-left: 300px; }
-	.container-sixteen .offset-by-six 					{ margin-left: 360px; }
-	.container-sixteen .offset-by-seven 				{ margin-left: 420px; }
-	.container-sixteen .offset-by-eight 				{ margin-left: 480px; }
-	.container-sixteen .offset-by-nine 					{ margin-left: 540px; }
-	.container-sixteen .offset-by-ten 					{ margin-left: 600px; }
-	.container-sixteen .offset-by-eleven 				{ margin-left: 660px; }
-	.container-sixteen .offset-by-twelve 				{ margin-left: 720px; }
-	.container-sixteen .offset-by-thirteen 				{ margin-left: 780px; }
-	.container-sixteen .offset-by-fourteen 				{ margin-left: 840px; }
-	.container-sixteen .offset-by-fifteen 				{ margin-left: 900px; }
-	
-	
-	
-	
-	
-	
-	
-	
+
+	/* Offsets */
+	.container-sixteen .offset-by-one 					{ margin-left: 70px;  }
+	.container-sixteen .offset-by-two 					{ margin-left: 130px; }
+	.container-sixteen .offset-by-three 				{ margin-left: 190px; }
+	.container-sixteen .offset-by-four 					{ margin-left: 250px; }
+	.container-sixteen .offset-by-five 					{ margin-left: 310px; }
+	.container-sixteen .offset-by-six 					{ margin-left: 370px; }
+	.container-sixteen .offset-by-seven 				{ margin-left: 430px; }
+	.container-sixteen .offset-by-eight 				{ margin-left: 490px; }
+	.container-sixteen .offset-by-nine 					{ margin-left: 550px; }
+	.container-sixteen .offset-by-ten 					{ margin-left: 610px; }
+	.container-sixteen .offset-by-eleven 				{ margin-left: 670px; }
+	.container-sixteen .offset-by-twelve 				{ margin-left: 730px; }
+	.container-sixteen .offset-by-thirteen 				{ margin-left: 790px; }
+	.container-sixteen .offset-by-fourteen 				{ margin-left: 850px; }
+	.container-sixteen .offset-by-fifteen 				{ margin-left: 910px; }
+
+
+
+
+
+
+
+
 /* #Tablet (Portrait)
-================================================== */	
+================================================== */
 
 	/* Note: Design for a width of 768px */
 
 	@media only screen and (min-width: 768px) and (max-width: 959px) {
 		.container { width: 768px; }
-		/*.container .column, 
+		/*.container .column,
 		.container .columns { margin-left: 10px; margin-right: 10px;  }*/
 		.column.alpha, .columns.alpha 				{ margin-left: 0; margin-right: 10px; }
 		.column.omega, .columns.omega 				{ margin-right: 0; margin-left: 10px; }
-	
+
 		.container .one-third.column				{ width: 236px; }
-		.container .two-thirds.column				{ width: 492px; }		
-		
+		.container .two-thirds.column				{ width: 492px; }
+
 		/*****************************
 			12 Column
 			((768/12) - 20) * 1 = 44
 		*****************************/
-			
+
 		.container-twelve .one.column 					{ width: 44px;  }
 		.container-twelve .two.columns 					{ width: 108px; }
 		.container-twelve .three.columns 				{ width: 172px; }
 		.container-twelve .four.columns 				{ width: 236px; }
 		.container-twelve .five.columns 				{ width: 300px; }
 		.container-twelve .six.columns 					{ width: 364px; }
-		.container-twelve .seven.columns 				{ width: 428px; }	
+		.container-twelve .seven.columns 				{ width: 428px; }
 		.container-twelve .eight.columns 				{ width: 492px; }
 		.container-twelve .nine.columns 				{ width: 556px; }
-		.container-twelve .ten.columns 					{ width: 620px; }	
-		.container-twelve .eleven.columns 				{ width: 684px; }	
+		.container-twelve .ten.columns 					{ width: 620px; }
+		.container-twelve .eleven.columns 				{ width: 684px; }
 		.container-twelve .twelve.columns 				{ width: 748px; }
-		
-			
-		
-		/* Offsets */	
-		.container-twelve .offset-by-one 				{ margin-left: 64px;  }
-		.container-twelve .offset-by-two 				{ margin-left: 128px; }
-		.container-twelve .offset-by-three 				{ margin-left: 192px; }
-		.container-twelve .offset-by-four 				{ margin-left: 256px; }
-		.container-twelve .offset-by-five 				{ margin-left: 320px; }
-		.container-twelve .offset-by-six 				{ margin-left: 384px; }
-		.container-twelve .offset-by-seven 				{ margin-left: 448px; }
-		.container-twelve .offset-by-eight 				{ margin-left: 512px; }
-		.container-twelve .offset-by-nine 				{ margin-left: 576px; }
-		.container-twelve .offset-by-ten 				{ margin-left: 640px; }
-		.container-twelve .offset-by-eleven 			{ margin-left: 704px; }
 
-	
 
-		
-		
+
+		/* Offsets */
+		.container-twelve .offset-by-one 				{ margin-left: 74px;  }
+		.container-twelve .offset-by-two 				{ margin-left: 138px; }
+		.container-twelve .offset-by-three 				{ margin-left: 202px; }
+		.container-twelve .offset-by-four 				{ margin-left: 266px; }
+		.container-twelve .offset-by-five 				{ margin-left: 330px; }
+		.container-twelve .offset-by-six 				{ margin-left: 394px; }
+		.container-twelve .offset-by-seven 				{ margin-left: 458px; }
+		.container-twelve .offset-by-eight 				{ margin-left: 522px; }
+		.container-twelve .offset-by-nine 				{ margin-left: 586px; }
+		.container-twelve .offset-by-ten 				{ margin-left: 650px; }
+		.container-twelve .offset-by-eleven 			{ margin-left: 714px; }
+
+
+
+
+
 		/*****************************
 			16 Column
 			((768/16) - 20) * 1 = 28
 		*****************************/
-			
+
 		.container-sixteen .one.column 						{ width: 28px;  }
 		.container-sixteen .two.columns 					{ width: 76px;  }
 		.container-sixteen .three.columns 					{ width: 124px; }
 		.container-sixteen .four.columns 					{ width: 172px; }
 		.container-sixteen .five.columns 					{ width: 220px; }
 		.container-sixteen .six.columns 					{ width: 268px; }
-		.container-sixteen .seven.columns 					{ width: 316px; }	
+		.container-sixteen .seven.columns 					{ width: 316px; }
 		.container-sixteen .eight.columns 					{ width: 364px; }
 		.container-sixteen .nine.columns 					{ width: 412px; }
-		.container-sixteen .ten.columns 					{ width: 460px; }	
-		.container-sixteen .eleven.columns 					{ width: 508px; }	
+		.container-sixteen .ten.columns 					{ width: 460px; }
+		.container-sixteen .eleven.columns 					{ width: 508px; }
 		.container-sixteen .twelve.columns 					{ width: 556px; }
-		.container-sixteen .thirteen.columns 				{ width: 604px; }	
-		.container-sixteen .fourteen.columns 				{ width: 652px; }	
+		.container-sixteen .thirteen.columns 				{ width: 604px; }
+		.container-sixteen .fourteen.columns 				{ width: 652px; }
 		.container-sixteen .fifteen.columns 				{ width: 700px; }
 		.container-sixteen .sixteen.columns 				{ width: 748px; }
-		
-			
-		
-		/* Offsets */	
-		.container-sixteen .offset-by-one 					{ margin-left: 48px;  }
-		.container-sixteen .offset-by-two 					{ margin-left: 96px;  }
-		.container-sixteen .offset-by-three 				{ margin-left: 144px; }
-		.container-sixteen .offset-by-four 					{ margin-left: 192px; }
-		.container-sixteen .offset-by-five 					{ margin-left: 240px; }
-		.container-sixteen .offset-by-six 					{ margin-left: 286px; }
-		.container-sixteen .offset-by-seven 				{ margin-left: 336px; }
-		.container-sixteen .offset-by-eight 				{ margin-left: 384px; }
-		.container-sixteen .offset-by-nine 					{ margin-left: 432px; }
-		.container-sixteen .offset-by-ten 					{ margin-left: 480px; }
-		.container-sixteen .offset-by-eleven 				{ margin-left: 528px; }
-		.container-sixteen .offset-by-twelve 				{ margin-left: 576px; }
-		.container-sixteen .offset-by-thirteen 				{ margin-left: 624px; }
-		.container-sixteen .offset-by-fourteen 				{ margin-left: 672px; }
-		.container-sixteen .offset-by-fifteen 				{ margin-left: 720px; }
+
+
+
+		/* Offsets */
+		.container-sixteen .offset-by-one 					{ margin-left: 58px;  }
+		.container-sixteen .offset-by-two 					{ margin-left: 106px;  }
+		.container-sixteen .offset-by-three 				{ margin-left: 154px; }
+		.container-sixteen .offset-by-four 					{ margin-left: 202px; }
+		.container-sixteen .offset-by-five 					{ margin-left: 250px; }
+		.container-sixteen .offset-by-six 					{ margin-left: 296px; }
+		.container-sixteen .offset-by-seven 				{ margin-left: 346px; }
+		.container-sixteen .offset-by-eight 				{ margin-left: 394px; }
+		.container-sixteen .offset-by-nine 					{ margin-left: 442px; }
+		.container-sixteen .offset-by-ten 					{ margin-left: 490px; }
+		.container-sixteen .offset-by-eleven 				{ margin-left: 538px; }
+		.container-sixteen .offset-by-twelve 				{ margin-left: 586px; }
+		.container-sixteen .offset-by-thirteen 				{ margin-left: 634px; }
+		.container-sixteen .offset-by-fourteen 				{ margin-left: 682px; }
+		.container-sixteen .offset-by-fifteen 				{ margin-left: 730px; }
 	}
-	
-	
-/*	#Mobile (Portrait) 
+
+
+/*	#Mobile (Portrait)
 ================================================== */
-	
+
 	/* Note: Design for a width of 320px */
-	
+
 	@media only screen and (max-width: 767px) {
 		.container { width: 300px; }
 		.columns, .column { margin: 0; }
-		
-		.container .one.column,
-		.container .two.columns,
-		.container .three.columns,
-		.container .four.columns,
-		.container .five.columns,
-		.container .six.columns,
-		.container .seven.columns,
-		.container .eight.columns,
-		.container .nine.columns,
-		.container .ten.columns,
-		.container .eleven.columns,
-		.container .twelve.columns,
-		.container .thirteen.columns,
-		.container .fourteen.columns,
-		.container .fifteen.columns,
-		.container .sixteen.columns, 
-		.container .one-third.column, 
-		.container .two-thirds.column  { width: 300px; }
-		
-		/* Offsets */	
-		.container .offset-by-one,				
-		.container .offset-by-two, 					
-		.container .offset-by-three, 				
-		.container .offset-by-four, 					
-		.container .offset-by-five, 					
-		.container .offset-by-six, 					
-		.container .offset-by-seven, 				
-		.container .offset-by-eight, 				
-		.container .offset-by-nine, 					
-		.container .offset-by-ten, 					
-		.container .offset-by-eleven, 				
-		.container .offset-by-twelve, 				
-		.container .offset-by-thirteen, 			
-		.container .offset-by-fourteen, 			
-		.container .offset-by-fifteen { margin-left: 0; } 			
-				
-	}	 
-	
-	
-/* #Mobile (Landscape)
-================================================== */
 
-	/* Note: Design for a width of 480px */
-	
-	@media only screen and (min-width: 480px) and (max-width: 767px) {
-		.container { width: 420px; }
-		.columns, .column { margin: 0; }
-		
 		.container .one.column,
 		.container .two.columns,
 		.container .three.columns,
@@ -278,18 +230,66 @@
 		.container .fourteen.columns,
 		.container .fifteen.columns,
 		.container .sixteen.columns,
-		.container .one-third.column, 
+		.container .one-third.column,
+		.container .two-thirds.column  { width: 300px; }
+
+		/* Offsets */
+		.container .offset-by-one,
+		.container .offset-by-two,
+		.container .offset-by-three,
+		.container .offset-by-four,
+		.container .offset-by-five,
+		.container .offset-by-six,
+		.container .offset-by-seven,
+		.container .offset-by-eight,
+		.container .offset-by-nine,
+		.container .offset-by-ten,
+		.container .offset-by-eleven,
+		.container .offset-by-twelve,
+		.container .offset-by-thirteen,
+		.container .offset-by-fourteen,
+		.container .offset-by-fifteen { margin-left: 0; }
+
+	}
+
+
+/* #Mobile (Landscape)
+================================================== */
+
+	/* Note: Design for a width of 480px */
+
+	@media only screen and (min-width: 480px) and (max-width: 767px) {
+		.container { width: 420px; }
+		.columns, .column { margin: 0; }
+
+		.container .one.column,
+		.container .two.columns,
+		.container .three.columns,
+		.container .four.columns,
+		.container .five.columns,
+		.container .six.columns,
+		.container .seven.columns,
+		.container .eight.columns,
+		.container .nine.columns,
+		.container .ten.columns,
+		.container .eleven.columns,
+		.container .twelve.columns,
+		.container .thirteen.columns,
+		.container .fourteen.columns,
+		.container .fifteen.columns,
+		.container .sixteen.columns,
+		.container .one-third.column,
 		.container .two-thirds.column { width: 420px; }
 	}
-	 
-	
+
+
 /* #Clearing
 ================================================== */
 
 	/* Self Clearing Goodness */
-	.container:after { content: "\0020"; display: block; height: 0; clear: both; visibility: hidden; } 
-	
-	/* Use clearfix class on parent to clear nested columns, 
+	.container:after { content: "\0020"; display: block; height: 0; clear: both; visibility: hidden; }
+
+	/* Use clearfix class on parent to clear nested columns,
 	or wrap each row of columns in a <div class="row"> */
 	.clearfix:before,
 	.clearfix:after,
@@ -304,10 +304,10 @@
 	.row:after,
 	.clearfix:after {
 	  clear: both; }
-	.row, 
+	.row,
 	.clearfix {
 	  zoom: 1; }
-	  
+
 	/* You can also use a <br class="clear" /> to clear columns */
 	.clear {
 	  clear: both;
@@ -317,6 +317,5 @@
 	  width: 0;
 	  height: 0;
 	}
-	
-	
-	
+
+


### PR DESCRIPTION
I added 10px to all offset-by-x css classes in skeleton.css.
These 10px come from the left margin that gets overridden by adding such a class to a column. 

For example: 
I have the following element `<div class="two columns offset-by-one"></div>`. 

This element is 140px wide for a regular desktop size screen. Normally without the offset-by-one class, this element would have 10px left-margin, but because we added the offset class, we overwrite this 10px left-margin. Thus we need to add these 10px to the offset class seeing as how they were not yet taken in consideration with the original calculation
